### PR TITLE
change: ２重登録させない制御をsession_idで判断するのではなく、セッションに登録されたキーで判断するように変更

### DIFF
--- a/Controller/LikesController.php
+++ b/Controller/LikesController.php
@@ -47,8 +47,8 @@ class LikesController extends LikesAppController {
 		if (! $this->request->is('post')) {
 			return $this->throwBadRequest();
 		}
-
-		if ($this->Like->existsLike($this->data['Like']['content_key'])) {
+		$md5SessionKey = $this->__getKey();
+		if ($this->Like->existsLike($this->data['Like']['content_key'], $md5SessionKey)) {
 			return;
 		}
 
@@ -58,9 +58,27 @@ class LikesController extends LikesAppController {
 			'conditions' => array('content_key' => $data['Like']['content_key'])
 		));
 		$data = Hash::merge($like, $data);
+		if (!Current::read('User.id')) {
+			$data['LikesUser']['session_key'] = $md5SessionKey;
+		}
 		if ($this->Like->saveLike($data)) {
 			return;
 		}
 		$this->NetCommons->handleValidationError($this->Like->validationErrors);
+	}
+
+/**
+ * session_keyを返す
+ *
+ * @return string
+ */
+	private function __getKey() {
+		$md5SessionKey = $this->Session->read('Likes.md5_session_key');
+		if ($md5SessionKey) {
+			return $md5SessionKey;
+		}
+		$md5SessionKey = md5(CakeSession::id());
+		$this->Session->write('Likes.md5_session_key', $md5SessionKey);
+		return $md5SessionKey;
 	}
 }

--- a/Model/Like.php
+++ b/Model/Like.php
@@ -176,9 +176,11 @@ class Like extends LikesAppModel {
  * Exists like data
  *
  * @param string $contentKey Content key of each plugin.
+ * @param string $md5SessionKey md5(SessionKey)
+ * @see https://github.com/researchmap/RmNetCommons3/issues/1750#issuecomment-596823362
  * @return bool
  */
-	public function existsLike($contentKey) {
+	public function existsLike($contentKey, $md5SessionKey = null) {
 		$this->LikesUser = ClassRegistry::init('Likes.LikesUser');
 
 		$joinConditions = array(
@@ -186,8 +188,11 @@ class Like extends LikesAppModel {
 		);
 		if (Current::read('User.id')) {
 			$joinConditions[$this->LikesUser->alias . '.user_id'] = Current::read('User.id');
+		} elseif (!is_null($md5SessionKey)) {
+			$joinConditions[$this->LikesUser->alias . '.session_key'] = (string)$md5SessionKey;
 		} else {
-			$joinConditions[$this->LikesUser->alias . '.session_key'] = (string)CakeSession::id();
+			// 常にインクリメント
+			return false;
 		}
 
 		$count = $this->find('count', array(
@@ -224,7 +229,6 @@ class Like extends LikesAppModel {
 		$this->begin();
 
 		//バリデーション
-		$data['LikesUser']['session_key'] = CakeSession::id();
 		$this->set($data);
 		if (! $this->validates()) {
 			$this->rollback();


### PR DESCRIPTION
https://github.com/researchmap/RmNetCommons3/issues/1750#issuecomment-596823362